### PR TITLE
WIP: add tests and partially revert regression for recursive types

### DIFF
--- a/src/rules/no-unsafe-readonly-mutable-assignment.test.ts
+++ b/src/rules/no-unsafe-readonly-mutable-assignment.test.ts
@@ -505,6 +505,60 @@ ruleTester.run("no-unsafe-readonly-mutable-assignment", rule, {
         }
       `,
     },
+    {
+      filename: "file.ts",
+      code: `
+        interface Foo {
+          foo: 'bar'
+        }
+
+        interface Bar {
+          foo: 'bar'
+        }
+
+        const foo: Recursive<Foo> = 42 as any
+        export default foo as Recursive<Bar>
+
+        type Recursive<P> = P | Nested<P>;
+        type Nested<P> = ReadonlyArray<Recursive<P>>;
+      `,
+    },
+    {
+      filename: "file.ts",
+      code: `
+        interface Foo {
+          foo: 'bar'
+        }
+
+        interface Bar {
+          foo: 'bar'
+        }
+
+        const foo: Recursive<Foo> = 42 as any
+        export default foo as Recursive<Bar>
+
+        type Recursive<P> = P | Nested<P>;
+        type Nested<P> = () => Recursive<P>
+      `,
+    },
+    {
+      filename: "file.ts",
+      code: `
+        interface Foo {
+          foo: 'bar'
+        }
+
+        interface Bar {
+          foo: 'bar'
+        }
+
+        const foo: Recursive<Foo> = 42 as any
+        export default foo as Recursive<Bar>
+
+        type Recursive<P> = P | Nested<P>;
+        type Nested<P> = { baz: Recursive<P> }
+      `,
+    },
   ],
   invalid: [
     /**

--- a/src/rules/unsafe-assignment-rule.ts
+++ b/src/rules/unsafe-assignment-rule.ts
@@ -340,6 +340,13 @@ export const createNoUnsafeAssignmentRule = (
 
     const isUnsafeFunctionAssignment = (typePairs: TypePairArray): boolean =>
       typePairs.some(({ sourceType, destinationType }) => {
+        // TODO https://github.com/danielnixon/eslint-plugin-total-functions/issues/100
+        // eslint-disable-next-line total-functions/no-unsafe-mutable-readonly-assignment
+        const nextSeenTypesWithPair: TypePairArray = nextSeenTypes.concat({
+          destinationType,
+          sourceType,
+        });
+
         const sourceCallSignatures = getCallSignaturesOfType(sourceType);
         const destinationCallSignatures = getCallSignaturesOfType(
           destinationType
@@ -385,7 +392,7 @@ export const createNoUnsafeAssignmentRule = (
                     sourceParameterType,
                     destinationParameterType,
                     checker,
-                    nextSeenTypes
+                    nextSeenTypesWithPair
                   );
                 });
             };
@@ -410,7 +417,7 @@ export const createNoUnsafeAssignmentRule = (
                 destinationReturnType,
                 sourceReturnType,
                 checker,
-                nextSeenTypes
+                nextSeenTypesWithPair
               ) ||
                 // or the parameter types of the functions are unsafe assignment.
                 isUnsafeParameterAssignment())
@@ -423,6 +430,13 @@ export const createNoUnsafeAssignmentRule = (
       objectTypePairs: TypePairArray
     ): boolean =>
       objectTypePairs.some(({ sourceType, destinationType }) => {
+        // TODO https://github.com/danielnixon/eslint-plugin-total-functions/issues/100
+        // eslint-disable-next-line total-functions/no-unsafe-mutable-readonly-assignment
+        const nextSeenTypesWithPair: TypePairArray = nextSeenTypes.concat({
+          destinationType,
+          sourceType,
+        });
+
         // This is an unsafe assignment if...
         return (
           // we're not in an infinitely recursive type,
@@ -444,7 +458,7 @@ export const createNoUnsafeAssignmentRule = (
             destinationType,
             sourceType,
             checker,
-            nextSeenTypes
+            nextSeenTypesWithPair
           ) ||
             // unsafe number index assignment, or
             isUnsafeIndexAssignment(
@@ -454,7 +468,7 @@ export const createNoUnsafeAssignmentRule = (
               destinationType,
               sourceType,
               checker,
-              nextSeenTypes
+              nextSeenTypesWithPair
             ) ||
             // unsafe property assignment.
             isUnsafePropertyAssignment(
@@ -463,7 +477,7 @@ export const createNoUnsafeAssignmentRule = (
               destinationType,
               sourceType,
               checker,
-              nextSeenTypes
+              nextSeenTypesWithPair
             ))
         );
       });


### PR DESCRIPTION
The reason this is a WIP as I've just checked and implementing your suggestion here:

> When comparing types to those previously seen, use mutual truth of checker.isTypeAssignableTo instead of ===. By "mutual" I mean a isTypeAssignableTo b and b isTypeAssignableTo a.

*seems* to obviate the need for the reverting of the change here, and still passes the tests introduced in this PR - but I want to make sure this isn't a false positive.

---

Thanks for looking so deeply into https://github.com/danielnixon/eslint-plugin-total-functions/issues/192! I've spent a few evenings thinking about it myself, but the unfamiliarity with the exact domain (I'm quite new to the TS checker API & architecture) means I've not made much progress.

Unfortunately
https://github.com/danielnixon/eslint-plugin-total-functions/commit/344e2c5dde393421d60a87eb029c4d3b4cc5d8f2

ended up introducing a regression that I found whilst trying to reduce my original styled-components failing case down to a smaller, testable scenario as mentioned here
https://github.com/danielnixon/eslint-plugin-total-functions/issues/192

The original, full-fat scenario still hangs with this PR, but at least the (unrelated?) regressions can be locked in via the tests.
There's a version with an array, a version with a function, and a version with an object (that didn't directly correspond to any changes, but I felt was worth checking for any).

Instead of just reverting the changes entirely, I've retained the raw types being added to the nextSeenTypes array, i.e.
```
    const nextSeenTypes: TypePairArray = seenTypes.concat({
      destinationType: rawDestinationType,
      sourceType: rawSourceType,
    });
```
This isn't actually necessary for the tests to pass (they pass if I fully revert the commit, i.e. don't collect the raw type as a seenType), but I'm assuming that's an important change - I'm just not sure if there is a test case for it, since you introduced it to try and help fix the styled-components scenario, and I've not had any luck boiling that one down into a simpler form yet.