### PR TITLE
Add npm package homepage and bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,11 @@
   "version": "7.1.0",
   "description": "An ESLint plugin to enforce the use of TypeScript total functions.",
   "main": "dist",
+  "homepage": "https://github.com/danielnixon/eslint-plugin-total-functions#readme",
   "repository": "https://github.com/danielnixon/eslint-plugin-total-functions.git",
+  "bugs": {
+    "url": "https://github.com/danielnixon/eslint-plugin-total-functions/issues"
+  },
   "author": "Daniel Nixon <dan.nixon@gmail.com>",
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
## Summary
- add npm `homepage` metadata pointing to the README
- add npm `bugs` metadata pointing to the GitHub issue tracker

## Validation
- `node -e "const p=require('./package.json'); if(!p.homepage||!p.bugs?.url) process.exit(1)"`
- `npm pack --dry-run --ignore-scripts`
- `git diff --check`